### PR TITLE
Quote Bug Fix: set quotes back to 'default' DB

### DIFF
--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -170,7 +170,7 @@ class AddDefaultValue(Operation):
         :param vendor: Connection vendor string as provided by the db backend
         """
         if self.is_default_vendor(vendor):
-            return
+            self.quotes["name"] = ('"', '"')
 
         if self.is_mysql(vendor):
             self.quotes["name"] = ("`", "`")


### PR DESCRIPTION
When different databases are set up, we might be using MSSql or MySQL quotes for a Postgresql DB.
See description in issue #11 

Fixes #11 

Ping @mes3yd since you seem to manage this repo. I would be very grateful if you could review, test, merge and publish to PyPi this bug fix ASAP. I'm working on a large refactoring of the migration linter (https://github.com/3YOURMIND/django-migration-linter) and this bug fix here would be appreciated to avoid that the tests there fail.

I'll try to do another PR anytime soon to refactor and try simplifying the code. In the current state, it is very complex complicated for such a simple task :thinking: 