### PR TITLE
fix(B3-5476): Monkeypatch quote_value

### DIFF
--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -13,6 +13,7 @@
 from __future__ import unicode_literals
 import warnings
 
+import django
 from django.db.migrations.operations.base import Operation
 from django.db import models
 from datetime import date, datetime
@@ -162,14 +163,12 @@ class AddDefaultValue(Operation):
         )
 
     def initialize_vendor_state(self, schema_editor):
-        import django
-
         self.set_quotes(schema_editor.connection.vendor)
         major, minor, patch, __, ___ = django.VERSION
         if (
             self.is_mysql(schema_editor.connection.vendor)
             and version_with_broken_quote_value(major, minor, patch)
-            and not getattr(schema_editor.__class__, "_patched_quote_value", False)
+            and not hasattr(schema_editor.__class__, "_patched_quote_value")
         ):
             schema_editor.__class__.quote_value = quote_value
             schema_editor.__class__._patched_quote_value = True
@@ -328,7 +327,7 @@ class AddDefaultValue(Operation):
 
 
 def version_with_broken_quote_value(major, minor, patch):
-    if 1 < major < 3:
+    if major == 2:
         if minor == 1 and patch < 9:
             return True
         elif minor == 2 and patch < 2:

--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -75,7 +75,7 @@ class AddDefaultValue(Operation):
         if not self.is_supported_vendor(schema_editor.connection.vendor):
             return
 
-        self.initialize_vendor_state(schema_editor.connection)
+        self.initialize_vendor_state(schema_editor)
 
         to_model = to_state.apps.get_model(app_label, self.model_name)
         if not self.can_apply_default(to_model, self.name, schema_editor.connection):
@@ -127,6 +127,8 @@ class AddDefaultValue(Operation):
         if not self.is_supported_vendor(schema_editor.connection.vendor):
             return
 
+        self.initialize_vendor_state(schema_editor)
+
         to_model = to_state.apps.get_model(app_label, self.model_name)
         if not self.can_apply_default(to_model, self.name, schema_editor.connection):
             return
@@ -159,8 +161,18 @@ class AddDefaultValue(Operation):
             {"model_name": self.model_name, "name": self.name, "value": self.value},
         )
 
-    def initialize_vendor_state(self, connection):
-        self.set_quotes(connection.vendor)
+    def initialize_vendor_state(self, schema_editor):
+        import django
+
+        self.set_quotes(schema_editor.connection.vendor)
+        major, minor, patch, __, ___ = django.VERSION
+        if (
+            self.is_mysql(schema_editor.connection.vendor)
+            and version_with_broken_quote_value(major, minor, patch)
+            and not getattr(schema_editor.__class__, "_patched_quote_value", False)
+        ):
+            schema_editor.__class__.quote_value = quote_value
+            schema_editor.__class__._patched_quote_value = True
 
     def set_quotes(self, vendor):
         """
@@ -313,3 +325,25 @@ class AddDefaultValue(Operation):
             return "CURRENT_TIMESTAMP", self.quotes["constant"], True
 
         return value, self.quotes["value"], False
+
+
+def version_with_broken_quote_value(major, minor, patch):
+    if 1 < major < 3:
+        if minor == 1 and patch < 9:
+            return True
+        elif minor == 2 and patch < 2:
+            return True
+
+    return False
+
+
+def quote_value(self, value):
+    self.connection.ensure_connection()
+
+    # MySQLdb escapes to string, PyMySQL to bytes.
+    quoted = self.connection.connection.escape(
+        value, self.connection.connection.encoders
+    )
+    if isinstance(value, str) and isinstance(quoted, bytes):
+        quoted = quoted.decode()
+    return quoted


### PR DESCRIPTION
The why: https://code.djangoproject.com/ticket/30371#comment:8

We set and read a class property we invented so that up- and downstream
software can correctly determine whether they should patch.