### PR TITLE
Add check on whether the migration should happen for a model

### DIFF
--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -79,6 +79,10 @@ class AddDefaultValue(Operation):
         self.initialize_vendor_state(schema_editor)
 
         to_model = to_state.apps.get_model(app_label, self.model_name)
+
+        if not self.allow_migrate_model(schema_editor.connection.alias, to_model):
+            return
+
         if not self.can_apply_default(to_model, self.name, schema_editor.connection):
             warnings.warn(
                 "You requested a default for a field / database combination "
@@ -131,6 +135,10 @@ class AddDefaultValue(Operation):
         self.initialize_vendor_state(schema_editor)
 
         to_model = to_state.apps.get_model(app_label, self.model_name)
+
+        if not self.allow_migrate_model(schema_editor.connection.alias, to_model):
+            return
+
         if not self.can_apply_default(to_model, self.name, schema_editor.connection):
             return
 


### PR DESCRIPTION
Same implemented in the [built-in](https://github.com/django/django/blob/f97bbad908df128189eff77d98af9a25ed1ecf23/django/db/migrations/operations/fields.py#L105) fields.

I have two databases running and when I run tests, the migrations for one database is running on the other as well, which shouldn't be the case.