### PR TITLE
Add CockroachDB support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ local_settings.py
 /test_project/test_project/settings_mssql.py
 /test_project/test_project/settings_mysql.py
 /test_project/test_project/settings_pgsql.py
+/test_project/test_project/settings_crdb.py
 
 # Flask stuff:
 instance/

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ bumpversion = "*"
 mysql-connector-python = "*"
 mysqlclient = "2.0.1"
 "psycopg2-binary" = "*"
+django-cockroachdb = ">=2.2"  # Use the version of django-cockroachdb that corresponds to your version of Django.
 tox = "*"
 black = "==18.6b4"
 ipython = "*"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supported Databases
 * MySQL (or compatible)
 * PostgreSQL
 * MSSQL (currently not tested)
+* CockroachDB
 
 Installation
 ------------

--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -244,6 +244,10 @@ class AddDefaultValue(Operation):
         return vendor.startswith("cockroachdb")
 
     @classmethod
+    def is_postgresql_syntax_compatible(cls, vendor):
+        return cls.is_postgresql(vendor) or cls.is_cockroachdb(vendor)
+
+    @classmethod
     def is_mariadb(cls, connection):
         if hasattr(connection, "mysql_is_mariadb"):
             return connection.mysql_is_mariadb()
@@ -281,7 +285,7 @@ class AddDefaultValue(Operation):
                  fields.
         :rtype: bool
         """
-        if cls.is_cockroachdb(connection.vendor) or cls.is_postgresql(connection.vendor) or cls.is_mssql(connection.vendor):
+        if cls.is_postgresql_syntax_compatible(connection.vendor) or cls.is_mssql(connection.vendor):
             return True
 
         if not hasattr(connection, "mysql_version") or not callable(
@@ -304,7 +308,7 @@ class AddDefaultValue(Operation):
         :param value: the value as provided in the migration
         :return: a 2-tuple containing the new value and the quotation to use
         """
-        if isinstance(value, bool) and not self.is_postgresql(vendor):
+        if isinstance(value, bool) and not self.is_postgresql_syntax_compatible(vendor):
             if value:
                 return 1, self.quotes["value"]
 
@@ -330,7 +334,7 @@ class AddDefaultValue(Operation):
             return value.isoformat(), self.quotes["value"], True
 
         if isinstance(value, datetime):
-            if self.is_postgresql(vendor):
+            if self.is_postgresql_syntax_compatible(vendor):
                 return (
                     value.isoformat(" ", timespec="seconds"),
                     self.quotes["value"],
@@ -348,7 +352,7 @@ class AddDefaultValue(Operation):
 
     def _clean_temporal_constants(self, vendor, value):
         if value == NOW or value == TODAY:
-            if self.is_postgresql(vendor):
+            if self.is_postgresql_syntax_compatible(vendor):
                 return "now()", self.quotes["function"], True
             elif self.is_mssql(vendor):
                 return "GETDATE()", self.quotes["function"], True

--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -281,7 +281,7 @@ class AddDefaultValue(Operation):
                  fields.
         :rtype: bool
         """
-        if cls.is_postgresql(connection.vendor) or cls.is_mssql(connection.vendor):
+        if cls.is_cockroachdb(connection.vendor) or cls.is_postgresql(connection.vendor) or cls.is_mssql(connection.vendor):
             return True
 
         if not hasattr(connection, "mysql_version") or not callable(

--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -285,7 +285,9 @@ class AddDefaultValue(Operation):
                  fields.
         :rtype: bool
         """
-        if cls.is_postgresql_syntax_compatible(connection.vendor) or cls.is_mssql(connection.vendor):
+        if cls.is_postgresql_syntax_compatible(connection.vendor) or cls.is_mssql(
+            connection.vendor
+        ):
             return True
 
         if not hasattr(connection, "mysql_version") or not callable(

--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -216,7 +216,12 @@ class AddDefaultValue(Operation):
 
     @classmethod
     def is_supported_vendor(cls, vendor):
-        return cls.is_postgresql(vendor) or cls.is_mysql(vendor) or cls.is_mssql(vendor)
+        return (
+            cls.is_postgresql(vendor)
+            or cls.is_mysql(vendor)
+            or cls.is_mssql(vendor)
+            or cls.is_cockroachdb(vendor)
+        )
 
     @classmethod
     def is_default_vendor(cls, vendor):
@@ -233,6 +238,10 @@ class AddDefaultValue(Operation):
     @classmethod
     def is_mssql(cls, vendor):
         return vendor.startswith("microsoft")
+
+    @classmethod
+    def is_cockroachdb(cls, vendor):
+        return vendor.startswith("cockroachdb")
 
     @classmethod
     def is_mariadb(cls, connection):

--- a/test_project/test_project/settings_crdb.sample.py
+++ b/test_project/test_project/settings_crdb.sample.py
@@ -1,0 +1,27 @@
+# flake8: noqa
+from .settings import *
+
+DBUSER = os.environ.get("CRDB_USER", "root")
+DBHOST = os.environ.get("CRDB_HOST", "localhost")
+DBPORT = None
+if not DBHOST.startswith("/"):
+    DBPORT = os.environ.get("CRDB_PORT", "26257")
+DBNAME = os.environ.get("CRDB_DATABASE", "defaultdb")
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django_cockroachdb",
+        "NAME": DBNAME,
+        "HOST": DBHOST,
+        "PORT": DBPORT,
+        "USER": DBUSER,
+    },
+}
+
+SECRET_KEY = "django_tests_secret_key"
+
+# Use a fast hasher to speed up tests.
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
+if os.environ.get("ADD_TEST_APP", False):
+    INSTALLED_APPS.append("dadv.apps.DadvConfig")

--- a/test_project/tests/__init__.py
+++ b/test_project/tests/__init__.py
@@ -105,7 +105,7 @@ class MigrationsTesterPgSQL(TestCase, MigrationsTesterBase):
 
 @unittest.skipUnless(
     settings_module == "test_project.settings_crdb",
-    "PostgreSQL/CockroachDB settings file not selected",
+    "CockroachDB settings file not selected",
 )
 @modify_settings(INSTALLED_APPS={"append": "dadv.apps.DadvConfig"})
 class MigrationsTesterCRDB(TestCase, MigrationsTesterBase):

--- a/test_project/tests/__init__.py
+++ b/test_project/tests/__init__.py
@@ -104,6 +104,28 @@ class MigrationsTesterPgSQL(TestCase, MigrationsTesterBase):
 
 
 @unittest.skipUnless(
+    settings_module == "test_project.settings_crdb",
+    "PostgreSQL/CockroachDB settings file not selected",
+)
+@modify_settings(INSTALLED_APPS={"append": "dadv.apps.DadvConfig"})
+class MigrationsTesterCRDB(TestCase, MigrationsTesterBase):
+    bool_match = "Add to field TestBoolDefault.is_functional the default value False"
+    text_match = "Add to field TestTextDefault.description the default value No description provided"
+    charfield_match = "Add to field TestHappyPath.name the default value Happy path"
+    date_match = "Add to field testhappypath.dob the default value 1970-01-01"
+    current_timestamp_match = (
+        "Add to field testhappypath.rebirth the default value __NOW__"
+    )
+    current_date_match = (
+        "Add to field testhappypath.married the default value __TODAY__"
+    )
+
+    custom_column_match = (
+        "Add to field TestCustomColumnName.is_functional the default value False"
+    )
+
+
+@unittest.skipUnless(
     settings_module == "test_project.settings_mysql", "MySQL settings file not selected"
 )
 @modify_settings(INSTALLED_APPS={"append": "dadv.apps.DadvConfig"})

--- a/test_project/tests/__init__.py
+++ b/test_project/tests/__init__.py
@@ -109,20 +109,7 @@ class MigrationsTesterPgSQL(TestCase, MigrationsTesterBase):
 )
 @modify_settings(INSTALLED_APPS={"append": "dadv.apps.DadvConfig"})
 class MigrationsTesterCRDB(TestCase, MigrationsTesterBase):
-    bool_match = "Add to field TestBoolDefault.is_functional the default value False"
-    text_match = "Add to field TestTextDefault.description the default value No description provided"
-    charfield_match = "Add to field TestHappyPath.name the default value Happy path"
-    date_match = "Add to field testhappypath.dob the default value 1970-01-01"
-    current_timestamp_match = (
-        "Add to field testhappypath.rebirth the default value __NOW__"
-    )
-    current_date_match = (
-        "Add to field testhappypath.married the default value __TODAY__"
-    )
-
-    custom_column_match = (
-        "Add to field TestCustomColumnName.is_functional the default value False"
-    )
+    pass
 
 
 @unittest.skipUnless(

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
     lint
     py{34,35,36,37}-django{11,20,21,22}-{pgsql,mysql}
     py{35,36,37}-django21-{pgsql,mysql}
-    py{35,36,37,38,39}-django22-{pgsql,mysql}
-    py{36,37,38,39}-django{30,31,32}-{pgsql,mysql}
+    py{35,36,37,38,39}-django22-{pgsql,mysql,crdb}
+    py{36,37,38,39}-django{30,31,32}-{pgsql,mysql,crdb}
     py27-django11-{pgsql,mysql}
 
 [flake8]
@@ -20,12 +20,13 @@ ignore = E501
 
 [testenv]
 changedir = {toxinidir}/test_project
-passenv = PGSQL_* MYSQL_*
+passenv = PGSQL_* MYSQL_* CRDB_*
 setenv =
     HOME={env:HOME}
     USER={env:USER}
     pgsql: DJANGO_SETTINGS_MODULE=test_project.settings_pgsql
     mysql: DJANGO_SETTINGS_MODULE=test_project.settings_mysql
+    crdb: DJANGO_SETTINGS_MODULE=test_project.settings_crdb
 commands = {envpython} manage.py test tests
 
 deps =
@@ -37,7 +38,11 @@ deps =
     django31: Django>=3.1,<3.1.99
     django32: Django>=3.2,<3.2.99
     mysql: mysqlclient>=2.0.1
-    pgsql: psycopg2-binary
+    pgsql,crdb: psycopg2-binary
+    django22-crdb: django-cockroachdb>=2.2,<2.2.99
+    django30-crdb: django-cockroachdb>=3.0,<3.0.99
+    django31-crdb: django-cockroachdb>=3.1,<3.1.99
+    django32-crdb: django-cockroachdb>=3.2,<3.2.99
 
 [testenv:lint]
 deps = flake8


### PR DESCRIPTION
Fixes #32 

Tested by running: `docker run -it -p 26257:26257 cockroachdb/cockroach:v20.2.8 start-single-node --insecure` in one terminal, and `tox . -e 'py38-django{22,30,31,32}-crdb'` in another.