### PR TITLE
fix: django-3.2 - 3.1 compatibility

### DIFF
--- a/django_add_default_value/add_default_value.py
+++ b/django_add_default_value/add_default_value.py
@@ -250,7 +250,10 @@ class AddDefaultValue(Operation):
     @classmethod
     def is_mariadb(cls, connection):
         if hasattr(connection, "mysql_is_mariadb"):
-            return connection.mysql_is_mariadb()
+            if callable(connection.mysql_is_mariadb):
+                return connection.mysql_is_mariadb()
+            else:
+                return connection.mysql_is_mariadb
         return False
 
     def can_apply_default(self, model, name, connection):


### PR DESCRIPTION
`connection.mysql_is_mariadb` is a method in django-3.1.x and a property in django-3.2.x.